### PR TITLE
fetch_zeroed_asg_lt(): describe_launch_templates doesn't like list wi…

### DIFF
--- a/amicleaner/fetch.py
+++ b/amicleaner/fetch.py
@@ -123,6 +123,7 @@ class Fetcher(object):
         zeroed_lt_versions = [lt.get("LaunchTemplateVersion", "")
                         for lt in zeroed_lts]
 
+        zeroed_lt_names = list(filter(None, zeroed_lt_names))
         resp = self.ec2.describe_launch_templates(
             LaunchTemplateNames=zeroed_lt_names
         )


### PR DESCRIPTION
…th empty string

In some cases `zeroed_lt_names` value might be `['']` which `ec2.describe_launch_templates()` doesn't like.

The error was:
```
Traceback (most recent call last):
  File "/usr/bin/amicleaner", line 11, in <module>
    load_entry_point('aws-amicleaner', 'console_scripts', 'amicleaner')()
  File "/aws-amicleaner/amicleaner/cli.py", line 197, in main
    app.run_cli()
  File "/aws-amicleaner/amicleaner/cli.py", line 167, in run_cli
    candidates = self.prepare_candidates()
  File "/aws-amicleaner/amicleaner/cli.py", line 68, in prepare_candidates
    candidates_amis = candidates_amis or self.fetch_candidates()
  File "/aws-amicleaner/amicleaner/cli.py", line 55, in fetch_candidates
    excluded_amis += f.fetch_zeroed_asg_lt()
  File "/aws-amicleaner/amicleaner/fetch.py", line 130, in fetch_zeroed_asg_lt
    LaunchTemplateNames=zeroed_lt_names
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 634, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 682, in _convert_to_request_dict
    api_params, operation_model)
  File "/usr/lib/python2.7/site-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid length for parameter LaunchTemplateNames[0], value: 0, valid range: 3-inf
```